### PR TITLE
volto hero block image instead of background customization

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@eeacms/volto-block-toc",
     "@eeacms/volto-eea-design-system",
     "@eeacms/volto-eea-website-theme",
+    "@eeacms/volto-hero-block",
     "@eeacms/volto-resize-helper",
     "@eeacms/volto-spotlight",
     "@plone-collective/volto-authomatic"
@@ -30,6 +31,7 @@
     "@eeacms/volto-datablocks": "*",
     "@eeacms/volto-eea-design-system": "*",
     "@eeacms/volto-eea-website-theme": "*",
+    "@eeacms/volto-hero-block": "^7.1.0",
     "@eeacms/volto-resize-helper": "*",
     "@eeacms/volto-spotlight": "*",
     "@plone-collective/volto-authomatic": "2.0.1",

--- a/src/customizations/@eeacms/volto-hero-block/components/Blocks/Hero/Hero.jsx
+++ b/src/customizations/@eeacms/volto-hero-block/components/Blocks/Hero/Hero.jsx
@@ -72,7 +72,6 @@ function Hero({
 
   return (
     <div
-      style={{ border: '1px solid red' }}
       className={cx(
         'eea hero-block',
         !image &&

--- a/src/customizations/@eeacms/volto-hero-block/components/Blocks/Hero/Hero.jsx
+++ b/src/customizations/@eeacms/volto-hero-block/components/Blocks/Hero/Hero.jsx
@@ -1,0 +1,145 @@
+import React, { useMemo } from 'react';
+import cx from 'classnames';
+import PropTypes from 'prop-types';
+import { isInternalURL } from '@plone/volto/helpers/Url/Url';
+import { isImageGif, getFieldURL } from '@eeacms/volto-hero-block/helpers';
+import { Image } from '@plone/volto/components';
+
+Hero.propTypes = {
+  image: PropTypes.string,
+  fullWidth: PropTypes.bool,
+  fullHeight: PropTypes.bool,
+  alignContent: PropTypes.string,
+  textAlign: PropTypes.string,
+  backgroundVariant: PropTypes.string,
+  quoted: PropTypes.bool,
+  spaced: PropTypes.bool,
+  inverted: PropTypes.bool,
+  textVariant: PropTypes.string,
+};
+
+function Hero({
+  overlay = true,
+  fullWidth = true,
+  fullHeight = true,
+  children,
+  spaced = false,
+  inverted = true,
+  styles,
+  height,
+  ...props
+}) {
+  const image = getFieldURL(props.image);
+  const isExternal = !isInternalURL(image);
+  const {
+    alignContent = 'center',
+    bg = 'center',
+    backgroundVariant = 'primary',
+  } = styles || {};
+
+  const containerCssStyles = React.useMemo(
+    () => ({
+      overflow: 'hidden',
+      ...(height && !fullHeight ? { height } : {}),
+    }),
+    [height, fullHeight],
+  );
+
+  const imageUrl = useMemo(() => {
+    if (isExternal) {
+      return image;
+    }
+
+    if (isImageGif(image)) {
+      return `${image}/@@images/image`;
+    }
+
+    return `${image}/@@images/image/huge`;
+  }, [image, isExternal]);
+
+  const imageStyle = useMemo(() => {
+    return {
+      position: 'absolute',
+      top: 0,
+      left: 0,
+      width: '100%',
+      height: '100%',
+      objectFit: 'cover',
+      objectPosition: bg,
+      zIndex: -1,
+    };
+  }, [bg]);
+
+  return (
+    <div
+      style={{ border: '1px solid red' }}
+      className={cx(
+        'eea hero-block',
+        !image &&
+          backgroundVariant &&
+          !fullWidth &&
+          `color-bg-${backgroundVariant}`,
+        {
+          spaced,
+          inverted,
+          'full-height': fullHeight,
+        },
+      )}
+    >
+      <div
+        className={cx(
+          'hero-block-image-wrapper',
+          !image &&
+            backgroundVariant &&
+            fullWidth &&
+            `color-bg-${backgroundVariant}`,
+          {
+            'full-width': fullWidth,
+          },
+        )}
+        style={containerCssStyles}
+      >
+        {imageUrl && <Image src={imageUrl} alt="" style={imageStyle} />}
+        {image && overlay && (
+          <div className="hero-block-image-overlay dark-overlay-4"></div>
+        )}
+      </div>
+      <div
+        className={cx(
+          'hero-block-inner-wrapper d-flex',
+          `flex-items-${alignContent}`,
+        )}
+        style={containerCssStyles}
+      >
+        <div className="hero-block-body">{children}</div>
+      </div>
+    </div>
+  );
+}
+
+Hero.Text = ({ children, quoted, styles }) => {
+  const { textVariant = 'white', textAlign = 'left' } = styles || {};
+  return (
+    <div
+      className={cx(
+        'hero-block-text',
+        `color-fg-${textVariant}`,
+        `text-${textAlign}`,
+        quoted ? 'quoted-wrapper' : '',
+      )}
+    >
+      {children}
+    </div>
+  );
+};
+
+Hero.Meta = ({ children, styles }) => {
+  const { buttonAlign = 'left' } = styles || {};
+  return (
+    <div className={cx('hero-block-meta', `text-${buttonAlign}`)}>
+      {children}
+    </div>
+  );
+};
+
+export default Hero;

--- a/src/customizations/@eeacms/volto-hero-block/components/Blocks/Hero/schema.js
+++ b/src/customizations/@eeacms/volto-hero-block/components/Blocks/Hero/schema.js
@@ -1,0 +1,209 @@
+import { addStyling } from '@plone/volto/helpers';
+import config from '@plone/volto/registry';
+
+import alignTopSVG from '@plone/volto/icons/move-up.svg';
+import alignCenterSVG from '@plone/volto/icons/row.svg';
+import alignBottomSVG from '@plone/volto/icons/move-down.svg';
+import clearSVG from '@plone/volto/icons/clear.svg';
+
+const ALIGN_INFO_MAP = {
+  top: [alignTopSVG, 'Top'],
+  center: [alignCenterSVG, 'Center'],
+  bottom: [alignBottomSVG, 'Bottom'],
+  '': [clearSVG, 'None'],
+};
+
+export const HeroBlockSchema = ({ data }) => {
+  return {
+    title: 'Hero',
+    fieldsets: [
+      {
+        id: 'default',
+        title: 'Default',
+        fields: [
+          'fullWidth',
+          'fullHeight',
+          ...(!data?.fullHeight ? ['height'] : []),
+          'quoted',
+          'spaced',
+          'inverted',
+          'buttonLabel',
+          'buttonLink',
+          'overlay',
+          'image',
+        ],
+      },
+      {
+        id: 'copyright',
+        title: 'Copyright',
+        fields: ['copyright', 'copyrightIcon', 'copyrightPosition'],
+      },
+    ],
+    properties: {
+      fullWidth: {
+        title: 'Full width',
+        type: 'boolean',
+        defaultValue: true,
+      },
+      fullHeight: {
+        title: 'Full height',
+        type: 'boolean',
+        defaultValue: true,
+      },
+      quoted: {
+        title: 'Quoted',
+        type: 'boolean',
+        defaultValue: false,
+      },
+      spaced: {
+        title: 'Spaced',
+        type: 'boolean',
+        defaultValue: false,
+      },
+      inverted: {
+        title: 'Inverted',
+        type: 'boolean',
+        defaultValue: true,
+      },
+      buttonLabel: {
+        title: 'Button label',
+        widget: 'textarea',
+      },
+      buttonLink: {
+        title: 'Button link',
+        widget: 'url',
+      },
+      overlay: {
+        title: 'Image darken overlay',
+        type: 'boolean',
+        defaultValue: true,
+      },
+      image: {
+        title: 'Image',
+        widget: 'attachedimage',
+      },
+      copyright: {
+        title: 'Text',
+      },
+      copyrightIcon: {
+        title: 'Icon',
+        description: (
+          <>
+            Ex. ri-copyright-line. See{' '}
+            <a target="_blank" rel="noopener" href="https://remixicon.com/">
+              Remix Icon set
+            </a>
+          </>
+        ),
+        default: 'ri-copyright-line',
+      },
+      copyrightPosition: {
+        title: 'Align',
+        widget: 'align',
+        actions: ['left', 'right'],
+        default: 'left',
+      },
+      height: {
+        title: 'Height',
+        description:
+          'Use CSS numeric dimmension (ex: 100px or 20vh). ' +
+          'Images cannnot be made smaller than min-height.',
+      },
+    },
+    required: [],
+  };
+};
+
+export const stylingSchema = (props) => {
+  const schema = addStyling(props);
+  schema.properties.styles.schema = {
+    title: 'Hero style',
+    block: 'hero',
+    fieldsets: [
+      {
+        id: 'default',
+        title: 'Default',
+        fields: [
+          'backgroundVariant',
+          'bg',
+          'alignContent',
+          'textAlign',
+          'textVariant',
+          'buttonVariant',
+          'buttonAlign',
+        ],
+      },
+    ],
+    properties: {
+      bg: {
+        title: 'Image position',
+        widget: 'align',
+        actions: Object.keys(ALIGN_INFO_MAP),
+        actionsInfoMap: ALIGN_INFO_MAP,
+        default: 'has--bg--center',
+      },
+      backgroundVariant: {
+        title: 'Background theme',
+        widget: 'theme_picker',
+        colors: [
+          ...(config.settings && config.settings.themeColors
+            ? config.settings.themeColors.map(({ value, title }) => ({
+                name: value,
+                label: title,
+              }))
+            : []),
+          //and add extra ones here
+        ],
+      },
+      alignContent: {
+        title: 'Content align',
+        choices: [
+          ['start', 'Top'],
+          ['center', 'Center'],
+          ['end', 'Bottom'],
+        ],
+        default: 'center',
+      },
+      textAlign: {
+        title: 'Text align',
+        widget: 'align',
+        actions: ['left', 'center', 'right'],
+        default: 'left',
+      },
+      textVariant: {
+        title: 'Text theme',
+        widget: 'theme_picker',
+        colors: [
+          ...(config.settings && config.settings.themeColors
+            ? config.settings.themeColors.map(({ value, title }) => ({
+                name: value,
+                label: title,
+              }))
+            : []),
+          //and add extra ones here
+        ],
+      },
+      buttonVariant: {
+        title: 'Button theme',
+        widget: 'theme_picker',
+        colors: [
+          ...(config.settings && config.settings.themeColors
+            ? config.settings.themeColors.map(({ value, title }) => ({
+                name: value,
+                label: title,
+              }))
+            : []),
+          //and add extra ones here
+        ],
+      },
+      buttonAlign: {
+        title: 'Button align',
+        widget: 'align',
+        actions: ['left', 'center', 'right'],
+        default: 'left',
+      },
+    },
+    required: [],
+  };
+  return schema;
+};


### PR DESCRIPTION
Task: https://taskman.eionet.europa.eu/issues/287497
This will load hero block as an image instead of background, because it indicates a small improvement in LCP.
Based on the improvement, the changes might be moved to volto-hero-block in the future.

Changes from this PR are fully compatible with the existing image editing options.